### PR TITLE
Support the static link file can link with C++

### DIFF
--- a/nand-utils.h
+++ b/nand-utils.h
@@ -9,6 +9,10 @@
 #ifndef NAND_UTILS_H
 #define NAND_UTILS_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifdef DEBUG
 #pragma message "debug mode is enabled"
 #endif
@@ -47,4 +51,7 @@ int nand_pass_fail(void);
 int nand_oob_setup(char *oob, char *data);
 int nand_oob_verify(char *oob, char *data);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/nand.h
+++ b/nand.h
@@ -9,6 +9,10 @@
 #ifndef NAND_H
 #define NAND_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <wiringPi.h>
 #include <time.h>
 
@@ -54,4 +58,7 @@ static inline const char *nand_get_read_error_msg(int status_code)
 	return nand_read_errmsg[-status_code];
 }
 
+#ifdef __cplusplus
+}
+#endif
 #endif


### PR DESCRIPTION
Without `extern`, the library made by this cannot link with C++. Therefore, I added it to support it.