### PR TITLE
Disable to use nanosleep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,11 @@ LIBS += -lasan \
         -static-libasan
 endif
 
+USE_NANOSLEEP = 0
+ifeq ($(USE_DEBUG), 1)
+CFLAGS += -DENABLE_NANOSLEEP
+endif
+
 ifeq ($(PREFIX),)
 PREFIX := /usr/local
 endif

--- a/nand-utils.c
+++ b/nand-utils.c
@@ -11,10 +11,17 @@
 
 void nand_delay_ns(int ns)
 {
+#ifdef ENABLE_NANOSLEEP
 	struct timespec req, rem;
 	req.tv_sec = 0;
 	req.tv_nsec = ns;
 	nanosleep(&req, &rem);
+#else
+	int i = 1000;
+	(void)ns;
+	while (i--)
+		asm("nop");
+#endif
 }
 
 void nand_write_pin_mode(void)


### PR DESCRIPTION
`nanosleep()` is not feasible for delaying the NAND chip. Therefore, I changed it from `nanosleep()` to loop-based waiting version"